### PR TITLE
Remove /etc/sysconfig/node_exporter

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,18 +18,11 @@ class node_exporter::service {
     refreshonly => true,
     subscribe   => File['/etc/systemd/system/node_exporter.service']
   }
-  file { '/etc/sysconfig/node_exporter':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    notify => Service['node_exporter'],
-  }
   service { 'node_exporter':
     ensure  => true,
     enable  => true,
     require => [
-      File['/etc/systemd/system/node_exporter.service'],
-      File['/etc/sysconfig/node_exporter']
+      File['/etc/systemd/system/node_exporter.service']
     ]
   }
 }


### PR DESCRIPTION
This does not seem to be a necessary requirement for any platform, it is an empty file and causes errors when run on Debian 10 due to the folder `/etc/sysconfig` not existing.  The other alternative is to have puppet ensure the directory exists first but if the file is not referenced and is empty we should just remove the file declaration.